### PR TITLE
Install TIRPC headers in CI to fix asyn build.

### DIFF
--- a/.ci-local/asyn-config.sh
+++ b/.ci-local/asyn-config.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -e -x
-
-[ -d "asyn/asynDriver" ] || exit 1
-
-[ -f "/usr/include/rpc/rpc.h" ] && exit 0
-
-[ -f "/usr/include/tirpc/rpc/rpc.h" ] && \
- echo "TIRPC=YES" >> "configure/CONFIG_SITE.Common.linux-x86_64"

--- a/.ci-local/os.set
+++ b/.ci-local/os.set
@@ -6,5 +6,3 @@ BASE_RECURSIVE=no
 
 PVDATABASE_REPONAME=pvDatabaseCPP
 PVDATABASE_REPOOWNER=epics-base
-
-ASYN_HOOK=.ci-local/asyn-config.sh

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -83,6 +83,10 @@ jobs:
       with:
         submodules: true
 
+    - name: "Install TIRPC Headers"
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y libtirpc-dev
+
     - name: "Install Linux OS Deps"
       if: ${{ matrix.deps == 'os' && runner.os == 'Linux' }}
       run: |

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -49,7 +49,7 @@ jobs:
             base: "7.0"
             deps: adsupport
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: gcc
             configuration: default
             base: "7.0"


### PR DESCRIPTION
GitHub Actions runners lack libtirpc-dev by default, causing missing rpc.h errors during ASYN dependency preparation. Install libtirpc-dev unconditionally for all Linux jobs to satisfy ASYN's default TIRPC=YES configuration [1].

[1] https://github.com/epics-modules/asyn/blame/d55786e0508b1f8244cfae943ebc5fffccfb7590/configure/CONFIG_SITE.Common.linux-x86_64#L8