### PR TITLE
Fix NDArrayInfo setting in ColorConvert

### DIFF
--- a/ADApp/ADSrc/NDArrayPool.cpp
+++ b/ADApp/ADSrc/NDArrayPool.cpp
@@ -291,10 +291,10 @@ NDArray* NDArrayPool::copy(NDArray *pIn, NDArray *pOut, bool copyData, bool copy
     pOut->dataType = pIn->dataType;
   }
   pOut->codec.name = pIn->codec.name;
-  pOut->compressedSize = pIn->compressedSize;
   if (copyData) {
     pIn->getInfo(&arrayInfo);
     numCopy = pIn->codec.empty() ? arrayInfo.totalBytes : pIn->compressedSize;
+    pOut->compressedSize = pIn->compressedSize;
     if (pOut->dataSize < numCopy) numCopy = pOut->dataSize;
     memcpy(pOut->pData, pIn->pData, numCopy);
   }

--- a/ADApp/pluginSrc/NDPluginColorConvert.cpp
+++ b/ADApp/pluginSrc/NDPluginColorConvert.cpp
@@ -38,7 +38,6 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
     NDArray *pArrayOut=NULL;
     size_t imageSize, rowSize, numRows;
     size_t dims[3];
-    NDDimension_t tmpDim;
     enum Colour {red, green, blue};
     double value;
     int colorMode=NDColorModeMono, bayerPattern=NDBayerRGGB;
@@ -92,14 +91,9 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[1] = rowSize;
                     dims[2] = numRows;
                     pArrayOut = this->pNDArrayPool->alloc(3, dims, pArray->dataType, 0, NULL);
-                    tmpDim = pArrayOut->dims[0];
-                    /* Copy everything except the data, e.g. uniqueId and timeStamp, attributes. */
-                    this->pNDArrayPool->copy(pArray, pArrayOut, 0);
-                    /* That replaced the dimensions in the output array, need to fix. */
-                    pArrayOut->ndims = 3;
-                    pArrayOut->dims[2] = pArrayOut->dims[1];
-                    pArrayOut->dims[1] = pArrayOut->dims[0];
-                    pArrayOut->dims[0] = tmpDim;
+                    /* Copy everything except the data and the dimensions,
+                     * e.g. uniqueId and timeStamp, attributes. */
+                    this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pOut = pDataOut;
                     pIn  = pDataIn;
@@ -123,13 +117,9 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[1] = 3;
                     dims[2] = numRows;
                     pArrayOut = this->pNDArrayPool->alloc(3, dims, pArray->dataType, 0, NULL);
-                    tmpDim = pArrayOut->dims[1];
-                    /* Copy everything except the data, e.g. uniqueId and timeStamp, attributes. */
-                    this->pNDArrayPool->copy(pArray, pArrayOut, 0);
-                    /* That replaced the dimensions in the output array, need to fix. */
-                    pArrayOut->ndims = 3;
-                    pArrayOut->dims[2] = pArrayOut->dims[1];
-                    pArrayOut->dims[1] = tmpDim;
+                    /* Copy everything except the data and the dimensions,
+                     * e.g. uniqueId and timeStamp, attributes. */
+                    this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pIn  = pDataIn;
                     if (falseColor) {
@@ -163,12 +153,9 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[1] = numRows;
                     dims[2] = 3;
                     pArrayOut = this->pNDArrayPool->alloc(3, dims, pArray->dataType, 0, NULL);
-                    tmpDim = pArrayOut->dims[2];
-                    /* Copy everything except the data, e.g. uniqueId and timeStamp, attributes. */
-                    this->pNDArrayPool->copy(pArray, pArrayOut, 0);
-                    /* That replaced the dimensions in the output array, need to fix. */
-                    pArrayOut->ndims = 3;
-                    pArrayOut->dims[2] = tmpDim;
+                    /* Copy everything except the data and the dimensions,
+                     * e.g. uniqueId and timeStamp, attributes. */
+                    this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pRedOut   = pDataOut;
                     pGreenOut = pDataOut + imageSize;
@@ -215,16 +202,10 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[2] = numRows;
                     // There is a problem: the uniqueId and timeStamp are not preserved!
                     pArrayOut = this->pNDArrayPool->alloc(3, dims, pArray->dataType, 0, NULL);
-                    tmpDim = pArrayOut->dims[0];
-                    this->pNDArrayPool->copy(pArray, pArrayOut, 0);
+                    this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
                     pArrayOut->uniqueId = pArray->uniqueId;
                     pArrayOut->epicsTS = pArray->epicsTS;
                     pArrayOut->timeStamp = pArray->timeStamp;
-                    pArrayOut->ndims = 3;
-                    pArrayOut->dims[2] = pArrayOut->dims[1];
-                    pArrayOut->dims[1] = pArrayOut->dims[0];
-                    pArrayOut->dims[0] = tmpDim;
-                    pArrayOut->dims[0].size = 3;
                     pDataOut = (epicsType *)pArrayOut->pData;
                     break;
 
@@ -233,15 +214,10 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[1] = 3;
                     dims[2] = numRows;
                     pArrayOut = this->pNDArrayPool->alloc(3, dims, pArray->dataType, 0, NULL);
-                    tmpDim = pArrayOut->dims[1];
-                    this->pNDArrayPool->copy(pArray, pArrayOut, 0);
+                    this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
                     pArrayOut->uniqueId = pArray->uniqueId;
                     pArrayOut->epicsTS = pArray->epicsTS;
                     pArrayOut->timeStamp = pArray->timeStamp;
-                    pArrayOut->ndims = 3;
-                    pArrayOut->dims[2] = pArrayOut->dims[1];
-                    pArrayOut->dims[1] = tmpDim;
-                    pArrayOut->dims[1].size = 3;
                     pDataOut = (epicsType *)pArrayOut->pData;
                     break;
 
@@ -250,14 +226,10 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[1] = numRows;
                     dims[2] = 3;
                     pArrayOut = this->pNDArrayPool->alloc(3, dims, pArray->dataType, 0, NULL);
-                    tmpDim = pArrayOut->dims[2];
-                    this->pNDArrayPool->copy(pArray, pArrayOut, 0);
+                    this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
                     pArrayOut->uniqueId = pArray->uniqueId;
                     pArrayOut->epicsTS = pArray->epicsTS;
                     pArrayOut->timeStamp = pArray->timeStamp;
-                    pArrayOut->ndims = 3;
-                    pArrayOut->dims[2] = tmpDim;
-                    pArrayOut->dims[2].size = 3;
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pRedOut   = pDataOut;
                     pGreenOut = pDataOut + imageSize;
@@ -380,12 +352,9 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[0] = rowSize;
                     dims[1] = numRows;
                     pArrayOut = this->pNDArrayPool->alloc(2, dims, pArray->dataType, 0, NULL);
-                    /* Copy everything except the data, e.g. uniqueId and timeStamp, attributes. */
-                    this->pNDArrayPool->copy(pArray, pArrayOut, 0);
-                    /* That replaced the dimensions in the output array, need to fix. */
-                    pArrayOut->ndims = 2;
-                    pArrayOut->dims[0] = pArrayOut->dims[1];
-                    pArrayOut->dims[1] = pArrayOut->dims[2];
+                    /* Copy everything except the data and the dimensions,
+                     * e.g. uniqueId and timeStamp, attributes. */
+                    this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pOut = pDataOut;
                     pIn = pDataIn;
@@ -397,7 +366,7 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     changedColorMode = 1;
                     break;
                 case NDColorModeRGB2:
-                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0);
+                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pIn = pDataIn;
                     for (i=0; i<numRows; i++) {
@@ -416,7 +385,7 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     changedColorMode = 1;
                     break;
                 case NDColorModeRGB3:
-                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0);
+                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pIn = pDataIn;
                     pRedOut   = pDataOut;
@@ -447,11 +416,9 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[0] = rowSize;
                     dims[1] = numRows;
                     pArrayOut = this->pNDArrayPool->alloc(2, dims, pArray->dataType, 0, NULL);
-                    /* Copy everything except the data, e.g. uniqueId and timeStamp, attributes. */
-                    this->pNDArrayPool->copy(pArray, pArrayOut, 0);
-                    /* That replaced the dimensions in the output array, need to fix. */
-                    pArrayOut->ndims = 2;
-                    pArrayOut->dims[1] = pArrayOut->dims[2];
+                    /* Copy everything except the data and the dimensions,
+                     * e.g. uniqueId and timeStamp, attributes. */
+                    this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pOut = pDataOut;
                     for (i=0; i<numRows; i++) {
@@ -466,7 +433,7 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     changedColorMode = 1;
                     break;
                 case NDColorModeRGB1:
-                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0);
+                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pOut = pDataOut;
                     for (i=0; i<numRows; i++) {
@@ -485,7 +452,7 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     changedColorMode = 1;
                     break;
                 case NDColorModeRGB3:
-                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0);
+                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pRedOut   = pDataOut;
                     pGreenOut = pDataOut + imageSize;
@@ -520,10 +487,9 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[0] = rowSize;
                     dims[1] = numRows;
                     pArrayOut = this->pNDArrayPool->alloc(2, dims, pArray->dataType, 0, NULL);
-                    /* Copy everything except the data, e.g. uniqueId and timeStamp, attributes. */
-                    this->pNDArrayPool->copy(pArray, pArrayOut, 0);
-                    /* That replaced the dimensions in the output array, need to fix. */
-                    pArrayOut->ndims = 2;
+                    /* Copy everything except the data and the dimensions,
+                     * e.g. uniqueId and timeStamp, attributes. */
+                    this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pOut = pDataOut;
                     pRedIn   = pDataIn;
@@ -536,7 +502,7 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     changedColorMode = 1;
                     break;
                 case NDColorModeRGB1:
-                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0);
+                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pRedIn   = pDataIn;
                     pGreenIn = pDataIn + imageSize;
@@ -553,7 +519,7 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     changedColorMode = 1;
                     break;
                 case NDColorModeRGB2:
-                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0);
+                    pArrayOut = this->pNDArrayPool->copy(pArray, NULL, 0, 0);
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pRedIn   = pDataIn;
                     pGreenIn = pDataIn + imageSize;

--- a/ADApp/pluginSrc/NDPluginColorConvert.cpp
+++ b/ADApp/pluginSrc/NDPluginColorConvert.cpp
@@ -200,12 +200,8 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[0] = 3;
                     dims[1] = rowSize;
                     dims[2] = numRows;
-                    // There is a problem: the uniqueId and timeStamp are not preserved!
                     pArrayOut = this->pNDArrayPool->alloc(3, dims, pArray->dataType, 0, NULL);
                     this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
-                    pArrayOut->uniqueId = pArray->uniqueId;
-                    pArrayOut->epicsTS = pArray->epicsTS;
-                    pArrayOut->timeStamp = pArray->timeStamp;
                     pDataOut = (epicsType *)pArrayOut->pData;
                     break;
 
@@ -215,9 +211,6 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[2] = numRows;
                     pArrayOut = this->pNDArrayPool->alloc(3, dims, pArray->dataType, 0, NULL);
                     this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
-                    pArrayOut->uniqueId = pArray->uniqueId;
-                    pArrayOut->epicsTS = pArray->epicsTS;
-                    pArrayOut->timeStamp = pArray->timeStamp;
                     pDataOut = (epicsType *)pArrayOut->pData;
                     break;
 
@@ -227,9 +220,6 @@ void NDPluginColorConvert::convertColor(NDArray *pArray)
                     dims[2] = 3;
                     pArrayOut = this->pNDArrayPool->alloc(3, dims, pArray->dataType, 0, NULL);
                     this->pNDArrayPool->copy(pArray, pArrayOut, 0, 0);
-                    pArrayOut->uniqueId = pArray->uniqueId;
-                    pArrayOut->epicsTS = pArray->epicsTS;
-                    pArrayOut->timeStamp = pArray->timeStamp;
                     pDataOut = (epicsType *)pArrayOut->pData;
                     pRedOut   = pDataOut;
                     pGreenOut = pDataOut + imageSize;

--- a/ADApp/pluginSrc/NDPluginColorConvert.h
+++ b/ADApp/pluginSrc/NDPluginColorConvert.h
@@ -35,7 +35,6 @@ public:
 
 protected:
     int NDPluginColorConvertColorModeOut;
-    #define FIRST_NDPLUGIN_COLOR_CONVERT_PARAM NDPluginColorConvertColorModeOut
     int NDPluginColorConvertFalseColor;
 
 private:

--- a/ADApp/pluginTests/ColorConvertPluginWrapper.cpp
+++ b/ADApp/pluginTests/ColorConvertPluginWrapper.cpp
@@ -1,0 +1,9 @@
+#include "ColorConvertPluginWrapper.h"
+
+ColorConvertPluginWrapper::ColorConvertPluginWrapper(
+    const std::string &port, const std::string &detectorPort)
+    : NDPluginColorConvert(port.c_str(), 50, 0, detectorPort.c_str(),
+                        0, 0, 0, 0, 0, 0),
+      AsynPortClientContainer(port) {}
+
+ColorConvertPluginWrapper::~ColorConvertPluginWrapper() { cleanup(); }

--- a/ADApp/pluginTests/ColorConvertPluginWrapper.h
+++ b/ADApp/pluginTests/ColorConvertPluginWrapper.h
@@ -1,0 +1,14 @@
+#ifndef ADAPP_PLUGINTESTS_COLORCONVERTPLUGINWRAPPER_H_
+#define ADAPP_PLUGINTESTS_COLORCONVERTPLUGINWRAPPER_H_
+
+#include <NDPluginColorConvert.h>
+#include "AsynPortClientContainer.h"
+
+class ColorConvertPluginWrapper : public NDPluginColorConvert, public AsynPortClientContainer
+{
+public:
+    ColorConvertPluginWrapper(const std::string& port, const std::string& detectorPort);
+    virtual ~ColorConvertPluginWrapper();
+};
+
+#endif /* ADAPP_PLUGINTESTS_COLORCONVERTPLUGINWRAPPER_H_ */

--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -40,6 +40,7 @@ ifeq ($(WITH_BOOST),YES)
   ADTestUtility_SRCS += ROIPluginWrapper.cpp
   ADTestUtility_SRCS += OverlayPluginWrapper.cpp
   ADTestUtility_SRCS += CodecPluginWrapper.cpp
+  ADTestUtility_SRCS += ColorConvertPluginWrapper.cpp
 
   PROD_IOC_Linux += plugin-test
   PROD_IOC_Darwin += plugin-test
@@ -55,6 +56,7 @@ ifeq ($(WITH_BOOST),YES)
   plugin-test_SRCS += test_NDPluginTimeSeries.cpp
   plugin-test_SRCS += test_NDPluginFFT.cpp
   plugin-test_SRCS += test_NDPluginCodec.cpp
+  plugin-test_SRCS += test_NDPluginColorConvert.cpp
   plugin-test_SRCS += test_NDPluginAttrPlot.cpp
   plugin-test_SRCS += test_NDPluginROI.cpp
   plugin-test_SRCS += test_NDPluginOverlay.cpp

--- a/ADApp/pluginTests/test_NDPluginColorConvert.cpp
+++ b/ADApp/pluginTests/test_NDPluginColorConvert.cpp
@@ -1,0 +1,145 @@
+#include <boost/test/tools/old/interface.hpp>
+#include <string.h>
+#include <stdlib.h>
+
+#include "boost/test/unit_test.hpp"
+
+#include <NDPluginDriver.h>
+#include <NDArray.h>
+#include <asynDriver.h>
+#include <NDPluginColorConvert.h>
+
+#include "testingutilities.h"
+#include "ColorConvertPluginWrapper.h"
+
+/* Dimensions of the test array: 8x8 of UInt16 */
+#define TEST_XSIZE 8
+#define TEST_YSIZE 8
+#define TEST_NELEMENTS (TEST_XSIZE * TEST_YSIZE)
+
+struct ColorConvertTestFixture
+{
+    NDArrayPool *arrayPool;
+    std::vector<NDArray*>pArrays;
+    std::vector<size_t> dims = {TEST_XSIZE, TEST_YSIZE};
+    asynNDArrayDriver *dummy_driver;
+    ColorConvertPluginWrapper *cc;
+    TestingPlugin* downstream_plugin;
+
+    ColorConvertTestFixture()
+    {
+        std::string dummy_port("simCC"), testport("testCC");
+        uniqueAsynPortName(dummy_port);
+        uniqueAsynPortName(testport);
+
+        dummy_driver = new asynNDArrayDriver(
+            dummy_port.c_str(), 1, 0, 0,
+            asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 0);
+        arrayPool = dummy_driver->pNDArrayPool;
+
+        pArrays.resize(1);
+        fillNDArraysFromPool(dims, NDUInt16, pArrays, arrayPool);
+
+        cc = new ColorConvertPluginWrapper(testport.c_str(), dummy_port.c_str());
+
+        // This is the mock downstream plugin
+        downstream_plugin = new TestingPlugin(testport.c_str(), 0);
+
+        cc->start();
+
+        cc->write(NDPluginDriverEnableCallbacksString, 1);
+        cc->write(NDPluginDriverBlockingCallbacksString, 1);
+    }
+
+    ~ColorConvertTestFixture()
+    {
+        delete cc;
+        delete dummy_driver;
+    }
+
+    void processArray(NDArray *pArray)
+    {
+        cc->lock();
+        cc->processCallbacks(pArray);
+        cc->unlock();
+    }
+
+    /* set array metadata and convert it to desider color mode*/
+    void prepareArray(NDArray *input, NDColorMode_t colorModeOut)
+    {
+        input->timeStamp = 1777406490.0;
+        cc->write(NDPluginColorConvertColorModeOutString, colorModeOut);
+        processArray(input);
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(ColorConvertTests, ColorConvertTestFixture)
+
+/* Check if metadata remains the same after color conversion
+ * and if the dimension matches the expected
+ * - RGB1 = [3, X, Y]
+ * - RGB2 = [X, 3, Y]
+ * - RGB3 = [X, Y, 3]
+ */
+
+/* From Mono to RGB1 */
+BOOST_AUTO_TEST_CASE(test_metadata_grayscale_to_rgb1)
+{
+    NDArray *input = pArrays[0];
+    BOOST_REQUIRE(input != NULL);
+
+    prepareArray(input, NDColorModeRGB1);
+
+    NDArray *output = downstream_plugin->arrays.back();
+    BOOST_REQUIRE(output != NULL);
+
+    BOOST_CHECK_EQUAL(output->uniqueId, input->uniqueId);
+    BOOST_CHECK_CLOSE(output->timeStamp, input->timeStamp, 0.001);
+    BOOST_CHECK_EQUAL(output->ndims, 3);
+    BOOST_CHECK_EQUAL(output->dims[0].size, 3);
+    BOOST_CHECK_EQUAL(output->dims[1].size, TEST_XSIZE);
+    BOOST_CHECK_EQUAL(output->dims[2].size, TEST_YSIZE);
+    BOOST_CHECK_EQUAL(output->compressedSize, output->dataSize);
+}
+
+ /* From Mono to RGB2 */
+BOOST_AUTO_TEST_CASE(test_metadata_grayscale_to_rgb2)
+{
+    NDArray *input = pArrays[0];
+    BOOST_REQUIRE(input != NULL);
+
+    prepareArray(input, NDColorModeRGB2);
+
+    NDArray *output = downstream_plugin->arrays.back();
+    BOOST_REQUIRE(output != NULL);
+
+    BOOST_CHECK_EQUAL(output->uniqueId, input->uniqueId);
+    BOOST_CHECK_CLOSE(output->timeStamp, input->timeStamp, 0.001);
+    BOOST_CHECK_EQUAL(output->ndims, 3);
+    BOOST_CHECK_EQUAL(output->dims[0].size, TEST_XSIZE);
+    BOOST_CHECK_EQUAL(output->dims[1].size, 3);
+    BOOST_CHECK_EQUAL(output->dims[2].size, TEST_YSIZE);
+    BOOST_CHECK_EQUAL(output->compressedSize, output->dataSize);
+}
+
+/* From Mono to RGB3 */
+BOOST_AUTO_TEST_CASE(test_metadata_grayscale_to_rgb3)
+{
+    NDArray *input = pArrays[0];
+    BOOST_REQUIRE(input != NULL);
+
+    prepareArray(input, NDColorModeRGB3);
+
+    NDArray *output = downstream_plugin->arrays.back();
+    BOOST_REQUIRE(output != NULL);
+
+    BOOST_CHECK_EQUAL(output->uniqueId, input->uniqueId);
+    BOOST_CHECK_CLOSE(output->timeStamp, input->timeStamp, 0.001);
+    BOOST_CHECK_EQUAL(output->ndims, 3);
+    BOOST_CHECK_EQUAL(output->dims[0].size, TEST_XSIZE);
+    BOOST_CHECK_EQUAL(output->dims[1].size, TEST_YSIZE);
+    BOOST_CHECK_EQUAL(output->dims[2].size, 3);
+    BOOST_CHECK_EQUAL(output->compressedSize, output->dataSize);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR was motivated after seeing different values of compressed and uncompressed size after performing a mono to RGB1 conversion.

